### PR TITLE
Add open graph support

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,35 @@
         <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        {% if USE_OPEN_GRAPH %}
+            {% if OPEN_GRAPH_FB_APP_ID %}
+                <meta property="fb:app_id" content="{{ OPEN_GRAPH_FB_APP_ID }}" />
+            {% endif %}
+            <meta property="og:site_name" content="{{ SITENAME }}" />
+            {% if article %}
+                <meta property="og:type" content="article" />
+                <meta property="og:title" content="{{ article.title|striptags }}" />
+                <meta property="og:url" content="{{ SITEURL }}/{{ article.url }}" />
+                <meta property="og:description" content="{{ article.summary|striptags }}" />
+                {% if article.tags %}
+                {% for tag in article.tags %}
+                    <meta property="article:tag" content="{{ tag }}" />
+                {% endfor %}
+                {% endif %}
+            {% elif page %}
+                <meta property="og:type" content="article" />
+                <meta property="og:title" content="{{ page.title|striptags }}" />
+                <meta property="og:url" content="{{ SITEURL }}/{{ page.url }}" />
+            {% else %}
+                <meta property="og:type" content="website" />
+                <meta property="og:title" content="{{ SITENAME }}" />
+                <meta property="og:url" content="{{ SITEURL }}" />
+                <meta property="og:description" content="{{ SITENAME }}" />
+                {% if OPEN_GRAPH_IMAGE %}
+                    <meta property="og:image" content="{{ SITEURL }}/static/{{ OPEN_GRAPH_IMAGE }}"/>
+                {% endif %}
+            {% endif %}
+        {% endif %}
         {% block stylesheets %}
         <link rel="stylesheet" href="{{ SITEURL }}/theme/css/normalize.css">
         <link href='//fonts.googleapis.com/css?family=Lato' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Hi,

I add a open graph code according to [pelican-bootstrap3](https://github.com/DandyDev/pelican-bootstrap3/blob/master/templates/base.html).
I also add some additional meta tags like `og:site_name`.
To enable this setting, just set `USE_OPEN_GRAPH` to `True` in the config file.

For more open graph information, you can check: http://ogp.me
For debugging: https://developers.facebook.com/tools/debug/
